### PR TITLE
little defensive bug fix

### DIFF
--- a/src/CLMS/model/SearchResultsModel.js
+++ b/src/CLMS/model/SearchResultsModel.js
@@ -99,7 +99,7 @@
                 var linkableResSet = new Set();
                 for (var s = 0; s < searchCount; s++) {
                     var search = searchArray[s];
-                    var crosslinkers = search.crosslinkers;
+                    var crosslinkers = search.crosslinkers || [];
                     var crosslinkerCount = crosslinkers.length;
                     for (var cl = 0; cl < crosslinkerCount ; cl++) {
                         var crosslinkerDescription = crosslinkers[cl].description;


### PR DESCRIPTION
tiny little defensive bug fix I did a couple of weeks ago. I must have loaded some dodgy search or maybe it's to do with the loading csv stuff. Anyways, it means crosslinkerCount is never undefined.